### PR TITLE
Do not run nccl backend in local mode in multiple containers.

### DIFF
--- a/test/integration/local/test_distributed_training.py
+++ b/test/integration/local/test_distributed_training.py
@@ -17,6 +17,11 @@ from test.integration import data_dir, dist_operations_path, mnist_script
 from test.utils import local_mode
 
 
+@pytest.fixture(scope='session', name='dist_gpu_backend', params=['gloo'])
+def fixture_dist_gpu_backend(request):
+    return request.param
+
+
 def test_dist_operations_path_cpu(docker_image, opt_ml, dist_cpu_backend):
     local_mode.train(dist_operations_path, data_dir, docker_image, opt_ml, cluster_size=3,
                      hyperparameters={'backend': dist_cpu_backend})


### PR DESCRIPTION
Do not run nccl backend in local mode in multiple containers because cuda device should not be shared between nccl workers. (Test hangs when is run on p2.xlarge, but works fine in p2.8xlarge, based on documentation cuda devices shouldn't be shared between nccl devices:
https://pytorch.org/docs/stable/distributed.html )

We do have integ tests that run on single host multi gpu to test nccl and on multiple hosts.
We also have single host multigpu nccl test in local mode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
