### PR TITLE
Add subdirectory to user module in local integ test

### DIFF
--- a/test/integration/local/test_single_machine_training.py
+++ b/test/integration/local/test_single_machine_training.py
@@ -12,11 +12,11 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 from test.utils import local_mode
-from test.integration import data_dir, mnist_script
+from test.integration import data_dir, mnist_script, mnist_path
 
 
 def test_mnist_cpu(docker_image, opt_ml, use_gpu):
-    local_mode.train(mnist_script, data_dir, docker_image, opt_ml, use_gpu=use_gpu)
+    local_mode.train(mnist_script, data_dir, docker_image, opt_ml, use_gpu=use_gpu, source_dir=mnist_path)
 
     assert local_mode.file_exists(opt_ml, 'model/model.pth'), 'Model file was not created'
     assert local_mode.file_exists(opt_ml, 'output/success'), 'Success file was not created'

--- a/test/resources/mnist/utils/dataloaders.py
+++ b/test/resources/mnist/utils/dataloaders.py
@@ -1,0 +1,30 @@
+import logging
+import sys
+
+import torch
+from torchvision import datasets, transforms
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
+
+def get_train_data_loader(batch_size, training_dir, is_distributed, **kwargs):
+    logger.info("Get train data loader")
+    dataset = datasets.MNIST(training_dir, train=True, transform=transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.1307,), (0.3081,))
+    ]))
+    train_sampler = torch.utils.data.distributed.DistributedSampler(dataset) if is_distributed else None
+    return torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=train_sampler is None,
+                                       sampler=train_sampler, **kwargs)
+
+
+def get_test_data_loader(test_batch_size, training_dir, **kwargs):
+    logger.info("Get test data loader")
+    return torch.utils.data.DataLoader(
+        datasets.MNIST(training_dir, train=False, transform=transforms.Compose([
+            transforms.ToTensor(),
+            transforms.Normalize((0.1307,), (0.3081,))
+        ])),
+        batch_size=test_batch_size, shuffle=True, **kwargs)


### PR DESCRIPTION
Moved some code from mnist.py into a separate file in a subdirectory so we have test coverage of this functionality for the pytorch images.

(This depends on the pip / python versions used in the image as well as the sagemaker-containers code, so I think its right to have this coverage here.)