### PR TITLE
Fix: pin coverage version to fix pipeline issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-test_dependencies = ['boto3', 'coverage', 'flake8', 'future', 'mock', 'pytest', 'pytest-cov',
+test_dependencies = ['boto3', 'coverage==6.5.0', 'flake8', 'future', 'mock', 'pytest', 'pytest-cov',
                      'pytest-xdist', 'sagemaker[local]<2', 'torch', 'torchvision', 'tox']
 
 setup(


### PR DESCRIPTION
*Issue #, if available:*
Latest coverage version will go with a `No data to report.` error.
Reverting coverage to 6.5.0 for unblocking the pipeline.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
